### PR TITLE
fix: release workflow with new composite npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,18 +24,12 @@ jobs:
           major: ${{ steps.release.outputs.major }}
           minor: ${{ steps.release.outputs.minor }}
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
-
-      - name: Ensure clean install
-        run: yarn install --immutable
-        if: ${{ steps.release.outputs.release_created }}
-
+      # -------------------------------------------------------------------------
+      # This section is useful only if you plan on publishing your package to NPM
+      # Remove it if you do not plan to publish to NPM
       - name: Publish to NPM
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: graasp/graasp-deploy/.github/actions/publish-to-npm@v1
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
+      # -------------------------------------------------------------------------


### PR DESCRIPTION
This PR updates the release-please workflow with the new composite workflow to publish to npm.

closes #80 