### PR TITLE
fix(fr): confusing context translations

### DIFF
--- a/src/langs/fr/context.json
+++ b/src/langs/fr/context.json
@@ -1,6 +1,6 @@
 {
-  "builder": "editeur",
-  "player": "lecteur",
-  "analytics": "analyseur",
-  "library": "bibliothèque"
+  "builder": "Builder",
+  "player": "Player",
+  "analytics": "Analyseur",
+  "library": "Bibliothèque"
 }


### PR DESCRIPTION
As highlighted by some users, the french translations for the views could be confused with the permissions. We could use the non-ambiguous `Builder` and `Player` instead.